### PR TITLE
Change result_to_response_hook to use AWS task

### DIFF
--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -160,14 +160,14 @@ class BraketSampler(Sampler, Structured):
         ):
             raise BinaryQuadraticModelStructureError("Problem graph incompatible with solver.")
 
-        future = self.solver.run(
+        aws_task = self.solver.run(
             Problem(ProblemType.ISING, h, J), self._s3_destination_folder, **solver_kwargs
-        ).async_result()
+        )
 
         variables = set(h).union(*J)
 
         hook = BraketSampler._result_to_response_hook(variables, SPIN)
-        return SampleSet.from_future(future, hook)
+        return SampleSet.from_future(aws_task, hook)
 
     def sample_qubo(self, Q: Dict[Tuple[int, int], int], **kwargs) -> SampleSet:
         """
@@ -215,16 +215,16 @@ class BraketSampler(Sampler, Structured):
             else:
                 quadratic[(u, v)] = bias
 
-        future = self.solver.run(
+        aws_task = self.solver.run(
             Problem(ProblemType.QUBO, linear, quadratic),
             self._s3_destination_folder,
             **solver_kwargs,
-        ).async_result()
+        )
 
         variables = set().union(*Q)
 
         hook = BraketSampler._result_to_response_hook(variables, BINARY)
-        return SampleSet.from_future(future, hook)
+        return SampleSet.from_future(aws_task, hook)
 
     def _process_solver_kwargs(self, **kwargs) -> Dict[str, Any]:
         """

--- a/test/unit_tests/braket/ocean_plugin/conftest.py
+++ b/test/unit_tests/braket/ocean_plugin/conftest.py
@@ -1,3 +1,16 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
 import json
 from unittest.mock import Mock
 
@@ -154,9 +167,7 @@ def sample_ising_common_testing(
     """Common testing of sample_qubo for Braket samplers"""
     task = Mock()
     sampler.solver.run.return_value = task
-    future = Mock()
-    task.async_result.return_value = future
-    future.result.return_value = AnnealingQuantumTaskResult.from_string(s3_ising_result)
+    task.result.return_value = AnnealingQuantumTaskResult.from_string(s3_ising_result)
     actual = sampler.sample_ising(linear, quadratic, **sample_kwargs)
     call_list = sampler.solver.run.call_args_list
     args, kwargs = call_list[0]
@@ -183,9 +194,7 @@ def sample_qubo_common_testing(
     """Common testing of sample_qubo for Braket samplers"""
     task = Mock()
     sampler.solver.run.return_value = task
-    future = Mock()
-    task.async_result.return_value = future
-    future.result.return_value = AnnealingQuantumTaskResult.from_string(s3_qubo_result)
+    task.result.return_value = AnnealingQuantumTaskResult.from_string(s3_qubo_result)
     Q = {(0, 0): 0, (1, 2): 1, (0, 2): 0}
     actual = sampler.sample_qubo(Q, **sample_kwargs)
     call_list = sampler.solver.run.call_args_list


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes: Change result_to_response_hook to use AWS task. Otherwise, result_to_response_hook will not wait for the task to finish because it's calling .result() on a future and it will not run_until_complete.

Ran tox successfully with 100% coverage.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
