### PR TITLE
More integ test bucket creation exception handling

### DIFF
--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -48,7 +48,13 @@ def s3_bucket(s3_resource, boto_session):
     try:
         bucket.create(ACL="private", CreateBucketConfiguration={"LocationConstraint": region_name})
     except ClientError as e:
-        if e.response["Error"]["Code"] == "BucketAlreadyOwnedByYou":
+        code = e.response["Error"]["Code"]
+
+        # Bucket exists in profile region
+        if code == "BucketAlreadyOwnedByYou":
+            pass
+        # Bucket exists in another region
+        elif code == "IllegalLocationConstraintException" and bucket.creation_date:
             pass
         else:
             raise e


### PR DESCRIPTION
If a developer has already run the integ tests in one region and then
tries to run them from another, the tests will fail with an
IllegalLocationConstraintException, which is the error thrown when a
user attempts to access an existing bucket from outside the region it
lives. This commit adds IllegalLocationConstraintException to the
exceptions to ignore.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
