### PR TITLE
Add optional logger to samplers

### DIFF
--- a/README.md
+++ b/README.md
@@ -138,6 +138,10 @@ print(dnx.min_vertex_cover(star_graph, embedded_sampler, answer_mode="histogram"
 ```
 These usage examples can also be found as python scripts in the `BRAKET_OCEAN_PLUGIN_ROOT/examples/` folder.
 
+### Debugging Logs
+
+Tasks sent to QPUs don't always complete right away. To view task status, you can enable debugging logs. An example of how to enable these logs is included in the repo: `BRAKET_OCEAN_PLUGIN_ROOT/examples/debug_*`. These examples enable task logging so that status updates are continuously printed to console after a quantum task is executed. The logs can also be configured to save to a file or output to another stream. You can use the debugging example to get information on the tasks you submit, such as the current status, so that you know when your task completes.
+
 ## Install Additional Packages for Testing
 Make sure to install test dependencies first:
 ```bash

--- a/examples/debug_braket_dwave_sampler_min_vertex.py
+++ b/examples/debug_braket_dwave_sampler_min_vertex.py
@@ -1,0 +1,39 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import logging
+
+import dwave_networkx as dnx
+import networkx as nx
+from braket.ocean_plugin import BraketDWaveSampler, BraketSamplerArns
+from dwave.system.composites import EmbeddingComposite
+
+logger = logging.getLogger("newLogger")  # create new logger
+logger.addHandler(
+    logging.FileHandler(filename="sampler_logs.txt", mode="a")
+)  # configure to log to file
+logger.setLevel(logging.DEBUG)  # log to file all log messages with level DEBUG or above
+
+s3_destination_folder = ("your-s3-bucket", "your-folder")
+
+# Pass in logger to BraketDWaveSampler
+sampler = BraketDWaveSampler(s3_destination_folder, BraketSamplerArns.DWAVE, logger=logger)
+
+star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
+
+# EmbeddingComposite automatically maps the problem to the structure of the solver.
+embedded_sampler = EmbeddingComposite(sampler)
+
+# The below result should be 0 because node 0 is connected to the 4 other nodes in a star graph
+# Add result to log file
+logger.info(dnx.min_vertex_cover(star_graph, embedded_sampler, answer_mode="histogram"))

--- a/examples/debug_braket_sampler_min_vertex.py
+++ b/examples/debug_braket_sampler_min_vertex.py
@@ -1,0 +1,37 @@
+# Copyright 2019-2019 Amazon.com, Inc. or its affiliates. All Rights Reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License"). You
+# may not use this file except in compliance with the License. A copy of
+# the License is located at
+#
+#     http://aws.amazon.com/apache2.0/
+#
+# or in the "license" file accompanying this file. This file is
+# distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF
+# ANY KIND, either express or implied. See the License for the specific
+# language governing permissions and limitations under the License.
+
+import logging
+import sys
+
+import dwave_networkx as dnx
+import networkx as nx
+from braket.ocean_plugin import BraketSampler, BraketSamplerArns
+from dwave.system.composites import EmbeddingComposite
+
+logger = logging.getLogger("newLogger")  # create new logger
+logger.addHandler(logging.StreamHandler(stream=sys.stdout))  # configure to print to sys.stdout
+logger.setLevel(logging.DEBUG)  # print to sys.stdout all log messages with level DEBUG or above
+
+s3_destination_folder = ("your-s3-bucket", "your-folder")
+
+# Pass in logger to BraketSampler
+sampler = BraketSampler(s3_destination_folder, BraketSamplerArns.DWAVE, logger=logger)
+
+star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
+
+# EmbeddingComposite automatically maps the problem to the structure of the solver.
+embedded_sampler = EmbeddingComposite(sampler)
+
+# The below result should be 0 because node 0 is connected to the 4 other nodes in a star graph
+logger.info(dnx.min_vertex_cover(star_graph, embedded_sampler, resultFormat="HISTOGRAM"))

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -15,6 +15,7 @@ from __future__ import annotations
 
 import copy
 from functools import lru_cache
+from logging import Logger, getLogger
 from typing import Any, Dict, List, Tuple, Union
 
 from boltons.dictutils import FrozenDict
@@ -34,6 +35,8 @@ class BraketDWaveSampler(BraketSampler):
             and key (index 1) that is the results destination folder in S3.
         device_arn (str): AWS quantum device arn. Default is D-Wave.
         aws_session (AwsSession): AwsSession to call AWS with.
+        logger (Logger): Python Logger object with which to write logs, such as `QuantumTask`
+            statuses while polling for task to complete. Default is `getLogger(__name__)`
 
     Examples:
         >>> from braket.ocean_plugin import BraketDWaveSampler
@@ -46,8 +49,9 @@ class BraketDWaveSampler(BraketSampler):
         s3_destination_folder: AwsSession.S3DestinationFolder,
         device_arn: str = BraketSamplerArns.DWAVE,
         aws_session: AwsSession = None,
+        logger: Logger = getLogger(__name__),
     ):
-        super().__init__(s3_destination_folder, device_arn, aws_session)
+        super().__init__(s3_destination_folder, device_arn, aws_session, logger)
 
     @property
     @lru_cache(maxsize=1)

--- a/test/unit_tests/braket/ocean_plugin/conftest.py
+++ b/test/unit_tests/braket/ocean_plugin/conftest.py
@@ -12,6 +12,7 @@
 # language governing permissions and limitations under the License.
 
 import json
+import logging
 from unittest.mock import Mock
 
 import pytest
@@ -153,6 +154,11 @@ def info(additional_metadata, task_metadata):
     return info
 
 
+@pytest.fixture
+def logger():
+    return logging.getLogger("newLogger")
+
+
 def sample_ising_common_testing(
     linear,
     quadratic,
@@ -163,6 +169,7 @@ def sample_ising_common_testing(
     backend_parameters,
     sample_kwargs,
     shots,
+    logger,
 ):
     """Common testing of sample_qubo for Braket samplers"""
     task = Mock()
@@ -180,6 +187,7 @@ def sample_ising_common_testing(
         assert problem.linear == linear
     assert problem.quadratic == quadratic
     assert args[1] == s3_destination_folder
+    assert kwargs["logger"] == logger
     assert kwargs["backend_parameters"] == backend_parameters
     assert kwargs["shots"] == shots
     assert isinstance(actual, SampleSet)
@@ -189,7 +197,14 @@ def sample_ising_common_testing(
 
 
 def sample_qubo_common_testing(
-    sampler, s3_qubo_result, info, s3_destination_folder, backend_parameters, sample_kwargs, shots
+    sampler,
+    s3_qubo_result,
+    info,
+    s3_destination_folder,
+    backend_parameters,
+    sample_kwargs,
+    shots,
+    logger,
 ):
     """Common testing of sample_qubo for Braket samplers"""
     task = Mock()
@@ -205,6 +220,7 @@ def sample_qubo_common_testing(
     assert problem.linear == {0: 0}
     assert problem.quadratic == {(1, 2): 1, (0, 2): 0}
     assert args[1] == s3_destination_folder
+    assert kwargs["logger"] == logger
     assert kwargs["backend_parameters"] == backend_parameters
     assert kwargs["shots"] == shots
     assert isinstance(actual, SampleSet)

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -51,10 +51,10 @@ def backend_parameters_2():
 
 @pytest.fixture
 @patch("braket.ocean_plugin.braket_sampler.AwsQpu")
-def braket_dwave_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder):
+def braket_dwave_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder, logger):
     mock_qpu.return_value.properties = braket_sampler_properties
     arn = BraketSamplerArns.DWAVE
-    sampler = BraketDWaveSampler(s3_destination_folder, arn, Mock())
+    sampler = BraketDWaveSampler(s3_destination_folder, arn, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     return sampler
 
@@ -89,6 +89,7 @@ def test_sample_ising_dict_success(
     backend_parameters_1,
     sample_kwargs_1,
     shots,
+    logger,
 ):
     sample_ising_common_testing(
         linear,
@@ -100,6 +101,7 @@ def test_sample_ising_dict_success(
         backend_parameters_1,
         sample_kwargs_1,
         shots,
+        logger,
     )
 
 
@@ -111,6 +113,7 @@ def test_sample_qubo_dict_success_backend_parameters(
     backend_parameters_1,
     sample_kwargs_1,
     shots,
+    logger,
 ):
     sample_qubo_common_testing(
         braket_dwave_sampler,
@@ -120,6 +123,7 @@ def test_sample_qubo_dict_success_backend_parameters(
         backend_parameters_1,
         sample_kwargs_1,
         shots,
+        logger,
     )
 
 
@@ -131,6 +135,7 @@ def test_sample_qubo_dict_success_no_backend_parameters(
     backend_parameters_2,
     sample_kwargs_2,
     shots,
+    logger,
 ):
     sample_qubo_common_testing(
         braket_dwave_sampler,
@@ -140,4 +145,5 @@ def test_sample_qubo_dict_success_no_backend_parameters(
         backend_parameters_2,
         sample_kwargs_2,
         shots,
+        logger,
     )

--- a/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
@@ -45,10 +45,10 @@ def backend_parameters(braket_dwave_parameters):
 
 @pytest.fixture
 @patch("braket.ocean_plugin.braket_sampler.AwsQpu")
-def braket_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder):
+def braket_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder, logger):
     mock_qpu.return_value.properties = braket_sampler_properties
     arn = BraketSamplerArns.DWAVE
-    sampler = BraketSampler(s3_destination_folder, arn, Mock())
+    sampler = BraketSampler(s3_destination_folder, arn, Mock(), logger)
     return sampler
 
 
@@ -102,6 +102,7 @@ def test_sample_ising_dict_success(
     backend_parameters,
     sample_kwargs,
     shots,
+    logger,
 ):
     sample_ising_common_testing(
         linear,
@@ -113,6 +114,7 @@ def test_sample_ising_dict_success(
         backend_parameters,
         sample_kwargs,
         shots,
+        logger,
     )
 
 
@@ -134,6 +136,7 @@ def test_sample_qubo_dict_success(
     backend_parameters,
     sample_kwargs,
     shots,
+    logger,
 ):
     sample_qubo_common_testing(
         braket_sampler,
@@ -143,4 +146,5 @@ def test_sample_qubo_dict_success(
         backend_parameters,
         sample_kwargs,
         shots,
+        logger,
     )


### PR DESCRIPTION
*Issue #, if available: N/A

*Description of changes:*
* Add optional logger to samplers

[build_files.tar.gz](https://github.com/aws/braket-ocean-python-plugin/files/4773579/build_files.tar.gz)

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.