### PR TITLE
documentation: Get Read the Docs working

### DIFF
--- a/.readthedocs.yml
+++ b/.readthedocs.yml
@@ -17,4 +17,6 @@ formats:
 python:
   version: 3.7
   install:
+    - method: pip
+      path: .
     - requirements: doc/requirements.txt

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -10,6 +10,7 @@ release = version
 copyright = "{}, Amazon.com".format(datetime.datetime.now().year)
 
 extensions = [
+    "sphinxcontrib.apidoc",
     "sphinx.ext.autodoc",
     "sphinx.ext.viewcode",
     "sphinx.ext.napoleon",
@@ -28,3 +29,10 @@ html_theme = "sphinx_rtd_theme"
 htmlhelp_basename = "{}doc".format(project)
 
 napoleon_use_rtype = False
+
+apidoc_module_dir = "../src/braket"
+apidoc_output_dir = "_apidoc"
+apidoc_excluded_paths = ["../test"]
+apidoc_separate_modules = True
+apidoc_module_first = True
+apidoc_extra_args = ["-f", "--implicit-namespaces", "-H", "API Reference"]

--- a/doc/requirements.txt
+++ b/doc/requirements.txt
@@ -1,2 +1,3 @@
 sphinx
 sphinx-rtd-theme
+sphinxcontrib-apidoc

--- a/setup.py
+++ b/setup.py
@@ -40,6 +40,7 @@ setup(
             "pytest-xdist",
             "sphinx",
             "sphinx-rtd-theme",
+            "sphinxcontrib-apidoc",
             "tox",
             "dwave-ocean-sdk",
         ]

--- a/tox.ini
+++ b/tox.ini
@@ -62,8 +62,8 @@ basepython = python3.7
 deps =
     sphinx
     sphinx-rtd-theme
+    sphinxcontrib-apidoc
 commands =
-    sphinx-apidoc -e -f -M --implicit-namespaces -H "API Reference" -o doc/_apidoc src/braket
     sphinx-build -E -T -b html doc build/documentation/html
 
 [testenv:serve-docs]


### PR DESCRIPTION
Fixed previously failing Read the Docs builds (see
aws/amazon-braket-default-simulator-python#46)

*Issue #, if available:*

*Description of changes:*

*Testing done:*

[build_files.tar.gz](https://github.com/aws/amazon-braket-ocean-plugin-python/files/5077525/build_files.tar.gz)

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
