### PR TITLE
fix: Remove hard-coded ARNs and replace with get_devices

### DIFF
--- a/examples/braket_sampler_min_vertex.py
+++ b/examples/braket_sampler_min_vertex.py
@@ -15,10 +15,16 @@ import dwave_networkx as dnx
 import networkx as nx
 from dwave.system.composites import EmbeddingComposite
 
+from braket.aws import AwsDevice
 from braket.ocean_plugin import BraketSampler
 
 s3_destination_folder = ("your-s3-bucket", "your-folder")
-sampler = BraketSampler(s3_destination_folder, "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6")
+
+# Get an online D-Wave device ARN
+device_arn = AwsDevice.get_devices(provider_names=["D-Wave Systems"], statuses=["ONLINE"])[0].arn
+print("Using device ARN", device_arn)
+
+sampler = BraketSampler(s3_destination_folder, device_arn)
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/examples/debug_braket_sampler_min_vertex.py
+++ b/examples/debug_braket_sampler_min_vertex.py
@@ -18,6 +18,7 @@ import dwave_networkx as dnx
 import networkx as nx
 from dwave.system.composites import EmbeddingComposite
 
+from braket.aws import AwsDevice
 from braket.ocean_plugin import BraketSampler
 
 logger = logging.getLogger("newLogger")  # create new logger
@@ -26,10 +27,12 @@ logger.setLevel(logging.DEBUG)  # print to sys.stdout all log messages with leve
 
 s3_destination_folder = ("your-s3-bucket", "your-folder")
 
+# Get an online D-Wave device ARN
+device_arn = AwsDevice.get_devices(provider_names=["D-Wave Systems"], statuses=["ONLINE"])[0].arn
+print("Using device ARN", device_arn)
+
 # Pass in logger to BraketSampler
-sampler = BraketSampler(
-    s3_destination_folder, "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6", logger=logger
-)
+sampler = BraketSampler(s3_destination_folder, device_arn, logger=logger)
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/src/braket/ocean_plugin/_version.py
+++ b/src/braket/ocean_plugin/_version.py
@@ -15,4 +15,4 @@
    Version number (major.minor.patch[-label])
 """
 
-__version__ = "1.0.0.post1"
+__version__ = "1.0.1"

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -21,7 +21,7 @@ from typing import Any, Dict, List, Tuple, Union
 from boltons.dictutils import FrozenDict
 from dimod import SampleSet
 
-from braket.aws import AwsSession
+from braket.aws import AwsDevice, AwsSession
 from braket.ocean_plugin.braket_sampler import BraketSampler
 from braket.ocean_plugin.braket_solver_metadata import BraketSolverMetadata
 from braket.tasks import QuantumTask
@@ -53,9 +53,12 @@ class BraketDWaveSampler(BraketSampler):
         logger: Logger = getLogger(__name__),
     ):
         if not device_arn:
-            # TODO: replace with call to programmatically use the API to get this
-            # once the API is ready
-            device_arn = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
+            try:
+                device_arn = AwsDevice.get_devices(
+                    provider_names=["D-Wave Systems"], statuses=["ONLINE"]
+                )[0].arn
+            except IndexError:
+                raise RuntimeError("No D-Wave devices online")
         super().__init__(s3_destination_folder, device_arn, aws_session, logger)
 
     @property

--- a/test/integ_tests/conftest.py
+++ b/test/integ_tests/conftest.py
@@ -18,12 +18,12 @@ import dwavebinarycsp as dbc
 import pytest
 from botocore.exceptions import ClientError
 
-from braket.aws.aws_session import AwsSession
+from braket.aws import AwsDevice, AwsSession
 
 
 @pytest.fixture
 def dwave_arn():
-    return "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
+    return AwsDevice.get_devices(provider_names=["D-Wave Systems"], statuses=["ONLINE"])[0].arn
 
 
 @pytest.fixture(scope="session")

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -62,14 +62,31 @@ def braket_dwave_sampler(
 
 
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
+@patch("braket.ocean_plugin.braket_dwave_sampler.AwsDevice")
 def test_default_device_arn(
-    mock_qpu, braket_sampler_properties, s3_destination_folder, logger, dwave_arn
+    dwave_sampler_mock_qpu,
+    sampler_mock_qpu,
+    braket_sampler_properties,
+    s3_destination_folder,
+    logger,
+    dwave_arn,
 ):
-    mock_qpu.return_value.properties = braket_sampler_properties
+    mock_device = Mock()
+    mock_device.arn = dwave_arn
+    dwave_sampler_mock_qpu.get_devices.return_value = [mock_device]
+    sampler_mock_qpu.return_value.properties = braket_sampler_properties
     sampler = BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     assert sampler._device_arn == dwave_arn
-    # TODO: replace with test for call to API to get default ARN
+
+
+@pytest.mark.xfail(raises=RuntimeError)
+@patch("braket.ocean_plugin.braket_dwave_sampler.AwsDevice")
+def test_default_device_arn_error(dwave_sampler_mock_qpu, s3_destination_folder, logger, dwave_arn):
+    mock_device = Mock()
+    mock_device.arn = dwave_arn
+    dwave_sampler_mock_qpu.get_devices.return_value = []
+    BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
 
 
 def test_parameters(braket_dwave_sampler):


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
* Now that we have AwsDevice.get_devices, remove hard-coded ARNs and replace with this method of using the API to get the online device ARN

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [X] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [X] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [X] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
