### PR TITLE
change: add json validation for device schema in unit tests

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
             "black",
             "flake8",
             "isort",
+            "jsonschema",
             "pre-commit",
             "pylint",
             "pytest",

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -95,7 +95,7 @@ def test_parameters(braket_dwave_sampler):
     assert isinstance(braket_dwave_sampler.parameters, FrozenDict)
 
 
-def test_properties(braket_dwave_sampler, provider_properties, service_properties):
+def test_properties(braket_dwave_sampler, provider_properties, service_properties_list):
     assert isinstance(braket_dwave_sampler.properties, FrozenDict)
     translated_provider_properties = {
         BraketSolverMetadata.DWAVE["properties"]["provider"][braket_key]: provider_properties[
@@ -104,10 +104,10 @@ def test_properties(braket_dwave_sampler, provider_properties, service_propertie
         for braket_key in provider_properties
     }
     translated_service_properties = {
-        BraketSolverMetadata.DWAVE["properties"]["service"][braket_key]: service_properties[
+        BraketSolverMetadata.DWAVE["properties"]["service"][braket_key]: service_properties_list[
             braket_key
         ]
-        for braket_key in service_properties
+        for braket_key in service_properties_list
     }
     translated_provider_properties.update(translated_service_properties)
     expected = FrozenDict(translated_provider_properties)

--- a/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
@@ -17,6 +17,7 @@ from unittest.mock import Mock, patch
 
 import pytest
 from boltons.dictutils import FrozenDict
+from braket.task_result import AnnealingTaskResult
 from braket.tasks import AnnealingQuantumTaskResult
 from conftest import (
     sample_ising_common_testing,
@@ -25,6 +26,7 @@ from conftest import (
     sample_qubo_quantum_task_common_testing,
 )
 from dimod.exceptions import BinaryQuadraticModelStructureError
+from jsonschema import validate
 
 from braket.ocean_plugin import BraketSampler, BraketSolverMetadata
 
@@ -84,8 +86,8 @@ def test_advantage_parameters(advantage_braket_sampler):
     assert isinstance(advantage_braket_sampler.parameters, FrozenDict)
 
 
-def test_properties(braket_sampler, provider_properties, service_properties):
-    provider_properties.update(service_properties)
+def test_properties(braket_sampler, provider_properties, service_properties_list):
+    provider_properties.update(service_properties_list)
     assert isinstance(braket_sampler.properties, FrozenDict)
     assert braket_sampler.properties == provider_properties
 
@@ -181,6 +183,7 @@ def test_get_task_sample_set_variables(
     del s3_dict["additionalMetadata"]["dwaveMetadata"]
     task = Mock()
     variables = [8, 9, 10]
+    validate(s3_dict, AnnealingTaskResult.schema())
     task.result.return_value = AnnealingQuantumTaskResult.from_string(json.dumps(s3_dict))
     actual = BraketSampler.get_task_sample_set(task, variables=variables)
     assert list(actual.variables) == variables


### PR DESCRIPTION
***Issue** #, if available:*

*Description of changes:*
Add json schema validation for device schemas within the tests.

*Testing done:*
Unit test validation added. Integ tests and unit tests still run.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [ x ] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [ x ] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [ x ] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ x ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ x ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
