### PR TITLE
fix: correct parameter types in sampler methods

### DIFF
--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -110,7 +110,7 @@ class BraketDWaveSampler(BraketSampler):
         )
 
     def sample_ising(
-        self, h: Union[Dict[int, int], List[int]], J: Dict[int, int], **kwargs
+        self, h: Union[Dict[int, float], List[float]], J: Dict[Tuple[int, int], float], **kwargs
     ) -> SampleSet:
         """
         Sample from the specified Ising model.
@@ -147,7 +147,7 @@ class BraketDWaveSampler(BraketSampler):
         return super().sample_ising(h, J, **kwargs)
 
     def sample_ising_quantum_task(
-        self, h: Union[Dict[int, int], List[int]], J: Dict[Tuple[int, int], float], **kwargs
+        self, h: Union[Dict[int, float], List[float]], J: Dict[Tuple[int, int], float], **kwargs
     ) -> QuantumTask:
         """
         Sample from the specified Ising model and return a `QuantumTask`. This has the same inputs
@@ -185,7 +185,7 @@ class BraketDWaveSampler(BraketSampler):
         """
         return super().sample_ising_quantum_task(h, J, **kwargs)
 
-    def sample_qubo(self, Q: Dict[Tuple[int, int], int], **kwargs) -> SampleSet:
+    def sample_qubo(self, Q: Dict[Tuple[int, int], float], **kwargs) -> SampleSet:
         """
         Sample from the specified QUBO.
 
@@ -213,7 +213,7 @@ class BraketDWaveSampler(BraketSampler):
         """
         return super().sample_qubo(Q, **kwargs)
 
-    def sample_qubo_quantum_task(self, Q: Dict[Tuple[int, int], int], **kwargs) -> QuantumTask:
+    def sample_qubo_quantum_task(self, Q: Dict[Tuple[int, int], float], **kwargs) -> QuantumTask:
         """
         Sample from the specified QUBO and return a `QuantumTask`. This has the same inputs
         as `BraketDWaveSampler.sample_qubo`.

--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -147,7 +147,7 @@ class BraketSampler(Sampler, Structured):
         return FrozenDict(edges)
 
     def sample_ising(
-        self, h: Union[Dict[int, int], List[int]], J: Dict[int, int], **kwargs
+        self, h: Union[Dict[int, float], List[float]], J: Dict[Tuple[int, int], float], **kwargs
     ) -> SampleSet:
         """
         Sample from the specified Ising model.
@@ -195,7 +195,7 @@ class BraketSampler(Sampler, Structured):
         return BraketSampler.get_task_sample_set(aws_task, variables)
 
     def sample_ising_quantum_task(
-        self, h: Union[Dict[int, int], List[int]], J: Dict[Tuple[int, int], float], **kwargs
+        self, h: Union[Dict[int, float], List[float]], J: Dict[Tuple[int, int], float], **kwargs
     ) -> QuantumTask:
         """
         Sample from the specified Ising model and return a `QuantumTask`. This has the same inputs
@@ -254,7 +254,7 @@ class BraketSampler(Sampler, Structured):
             **solver_kwargs,
         )
 
-    def sample_qubo(self, Q: Dict[Tuple[int, int], int], **kwargs) -> SampleSet:
+    def sample_qubo(self, Q: Dict[Tuple[int, int], float], **kwargs) -> SampleSet:
         """
         Sample from the specified QUBO.
 
@@ -288,7 +288,7 @@ class BraketSampler(Sampler, Structured):
         variables = set().union(*Q)
         return BraketSampler.get_task_sample_set(aws_task, variables)
 
-    def sample_qubo_quantum_task(self, Q: Dict[Tuple[int, int], int], **kwargs) -> QuantumTask:
+    def sample_qubo_quantum_task(self, Q: Dict[Tuple[int, int], float], **kwargs) -> QuantumTask:
         """
         Sample from the specified QUBO and return a `QuantumTask`. This has the same inputs
         as `BraketSampler.sample_qubo`


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
The type hints of the parameters in several of the sampling method are not accurate. This change fixes those types.

*Testing done:*

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [ ] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [ ] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
