### PR TITLE
change: make s3_folder optional

### DIFF
--- a/examples/braket_dwave_sampler_factoring.py
+++ b/examples/braket_dwave_sampler_factoring.py
@@ -26,10 +26,8 @@ from braket.ocean_plugin import BraketDWaveSampler
 # Getting the SampleSet from the quantum task object
 
 
-# Declare folder to save S3 results
-s3_destination_folder = ("your-s3-bucket", "your-folder")
 # Declare sampler
-sampler = BraketDWaveSampler(s3_destination_folder)
+sampler = BraketDWaveSampler()
 
 integer_to_factor = 15
 

--- a/examples/braket_dwave_sampler_min_vertex.py
+++ b/examples/braket_dwave_sampler_min_vertex.py
@@ -17,8 +17,7 @@ from dwave.system.composites import EmbeddingComposite
 
 from braket.ocean_plugin import BraketDWaveSampler
 
-s3_destination_folder = ("your-s3-bucket", "your-folder")
-sampler = BraketDWaveSampler(s3_destination_folder)
+sampler = BraketDWaveSampler()
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/examples/braket_sampler_min_vertex.py
+++ b/examples/braket_sampler_min_vertex.py
@@ -13,18 +13,13 @@
 
 import dwave_networkx as dnx
 import networkx as nx
-from braket.aws import AwsDevice
 from dwave.system.composites import EmbeddingComposite
 
 from braket.ocean_plugin import BraketSampler
 
-s3_destination_folder = ("your-s3-bucket", "your-folder")
-
-# Get an online D-Wave device ARN
-device_arn = AwsDevice.get_devices(provider_names=["D-Wave Systems"], statuses=["ONLINE"])[0].arn
-print("Using device ARN", device_arn)
-
-sampler = BraketSampler(s3_destination_folder, device_arn)
+# Use a default online D-Wave device ARN
+sampler = BraketSampler()
+print("Using device ARN", sampler.solver.arn)
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/examples/debug_braket_dwave_sampler_min_vertex.py
+++ b/examples/debug_braket_dwave_sampler_min_vertex.py
@@ -25,10 +25,8 @@ logger.addHandler(
 )  # configure to log to file
 logger.setLevel(logging.DEBUG)  # log to file all log messages with level DEBUG or above
 
-s3_destination_folder = ("your-s3-bucket", "your-folder")
-
 # Pass in logger to BraketDWaveSampler
-sampler = BraketDWaveSampler(s3_destination_folder, logger=logger)
+sampler = BraketDWaveSampler(logger=logger)
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/examples/debug_braket_sampler_min_vertex.py
+++ b/examples/debug_braket_sampler_min_vertex.py
@@ -16,7 +16,6 @@ import sys
 
 import dwave_networkx as dnx
 import networkx as nx
-from braket.aws import AwsDevice
 from dwave.system.composites import EmbeddingComposite
 
 from braket.ocean_plugin import BraketSampler
@@ -25,14 +24,8 @@ logger = logging.getLogger("newLogger")  # create new logger
 logger.addHandler(logging.StreamHandler(stream=sys.stdout))  # configure to print to sys.stdout
 logger.setLevel(logging.DEBUG)  # print to sys.stdout all log messages with level DEBUG or above
 
-s3_destination_folder = ("your-s3-bucket", "your-folder")
-
-# Get an online D-Wave device ARN
-device_arn = AwsDevice.get_devices(provider_names=["D-Wave Systems"], statuses=["ONLINE"])[0].arn
-print("Using device ARN", device_arn)
-
 # Pass in logger to BraketSampler
-sampler = BraketSampler(s3_destination_folder, device_arn, logger=logger)
+sampler = BraketSampler(logger=logger)
 
 star_graph = nx.star_graph(4)  # star graph where node 0 is connected to 4 other nodes
 

--- a/setup.py
+++ b/setup.py
@@ -27,7 +27,7 @@ setup(
     packages=find_namespace_packages(where="src", exclude=("test",)),
     package_dir={"": "src"},
     install_requires=[
-        "amazon-braket-sdk",
+        "amazon-braket-sdk>=1.10.0",
         "boto3>=1.18.13",
         "boltons>=20.0.0",
         "colorama>=0.4.3",

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -48,8 +48,8 @@ class BraketDWaveSampler(BraketSampler):
 
     def __init__(
         self,
-        s3_destination_folder: AwsSession.S3DestinationFolder,
         device_arn: str = None,
+        s3_destination_folder: AwsSession.S3DestinationFolder = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),
     ):
@@ -60,7 +60,7 @@ class BraketDWaveSampler(BraketSampler):
                 )[0].arn
             except IndexError:
                 raise RuntimeError("No D-Wave devices online")
-        super().__init__(s3_destination_folder, device_arn, aws_session, logger)
+        super().__init__(device_arn, s3_destination_folder, aws_session, logger)
 
     @property
     @lru_cache(maxsize=1)
@@ -138,7 +138,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -151,7 +151,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -191,7 +191,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -206,7 +206,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -236,7 +236,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocess="SAMPLING", num_reads=100)
             >>> for sample in sampleset.samples():
@@ -249,7 +249,7 @@ class BraketDWaveSampler(BraketSampler):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, num_reads=100)
             >>> for sample in sampleset.samples():
@@ -280,7 +280,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -295,7 +295,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -131,7 +131,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -144,7 +144,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -184,7 +184,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -199,7 +199,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -229,7 +229,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocess="SAMPLING", num_reads=100)
             >>> for sample in sampleset.samples():
@@ -242,7 +242,7 @@ class BraketDWaveSampler(BraketSampler):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, num_reads=100)
             >>> for sample in sampleset.samples():
@@ -273,7 +273,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -288,7 +288,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketDWaveSampler(device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -20,7 +20,7 @@ from typing import Any, Dict, List, Tuple, Union
 
 import jsonref
 from boltons.dictutils import FrozenDict
-from braket.aws import AwsDevice, AwsSession
+from braket.aws import AwsSession
 from braket.tasks import QuantumTask
 from dimod import SampleSet
 
@@ -48,19 +48,12 @@ class BraketDWaveSampler(BraketSampler):
 
     def __init__(
         self,
-        device_arn: str = None,
         s3_destination_folder: AwsSession.S3DestinationFolder = None,
+        device_arn: str = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),
     ):
-        if not device_arn:
-            try:
-                device_arn = AwsDevice.get_devices(
-                    provider_names=["D-Wave Systems"], statuses=["ONLINE"]
-                )[0].arn
-            except IndexError:
-                raise RuntimeError("No D-Wave devices online")
-        super().__init__(device_arn, s3_destination_folder, aws_session, logger)
+        super().__init__(s3_destination_folder, device_arn, aws_session, logger)
 
     @property
     @lru_cache(maxsize=1)
@@ -138,7 +131,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -151,7 +144,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, answer_mode="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -191,7 +184,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -206,7 +199,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, answer_mode="HISTOGRAM")
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -236,7 +229,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocess="SAMPLING", num_reads=100)
             >>> for sample in sampleset.samples():
@@ -249,7 +242,7 @@ class BraketDWaveSampler(BraketSampler):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, num_reads=100)
             >>> for sample in sampleset.samples():
@@ -280,7 +273,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)
@@ -295,7 +288,7 @@ class BraketDWaveSampler(BraketSampler):
 
             >>> from braket.ocean_plugin import BraketDWaveSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketDWaveSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketDWaveSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, answer_mode="HISTOGRAM", num_reads=100)
             >>> sampleset = BraketDWaveSampler.get_task_sample_set(task)

--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -46,13 +46,13 @@ class BraketSampler(Sampler, Structured):
     Examples:
         >>> from braket.ocean_plugin import BraketSampler
         >>> s3_destination_folder = ('test_bucket', 'test_folder')
-        >>> sampler = BraketSampler(s3_destination_folder, "device_arn_1")
+        >>> sampler = BraketSampler("device_arn_1", s3_destination_folder)
     """
 
     def __init__(
         self,
-        s3_destination_folder: AwsSession.S3DestinationFolder,
         device_arn: str,
+        s3_destination_folder: AwsSession.S3DestinationFolder = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),
     ):
@@ -179,7 +179,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -192,7 +192,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -243,7 +243,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -257,7 +257,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -308,7 +308,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocessingType="SAMPLING", shots=100)
             >>> for sample in sampleset.samples():
@@ -321,7 +321,7 @@ class BraketSampler(Sampler, Structured):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, shots=100)
             >>> for sample in sampleset.samples():
@@ -359,7 +359,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -374,7 +374,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder, device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)

--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -46,16 +46,24 @@ class BraketSampler(Sampler, Structured):
     Examples:
         >>> from braket.ocean_plugin import BraketSampler
         >>> s3_destination_folder = ('test_bucket', 'test_folder')
-        >>> sampler = BraketSampler("device_arn_1", s3_destination_folder)
+        >>> sampler = BraketSampler(s3_destination_folder, "device_arn_1")
     """
 
     def __init__(
         self,
-        device_arn: str,
         s3_destination_folder: AwsSession.S3DestinationFolder = None,
+        device_arn: str = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),
     ):
+        if not device_arn:
+            try:
+                device_arn = AwsDevice.get_devices(
+                    provider_names=["D-Wave Systems"], statuses=["ONLINE"]
+                )[0].arn
+            except IndexError:
+                raise RuntimeError("No D-Wave devices online")
+
         self._s3_destination_folder = s3_destination_folder
         self._device_arn = device_arn
         self._logger = logger
@@ -179,7 +187,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -192,7 +200,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -243,7 +251,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -257,7 +265,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -308,7 +316,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocessingType="SAMPLING", shots=100)
             >>> for sample in sampleset.samples():
@@ -321,7 +329,7 @@ class BraketSampler(Sampler, Structured):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, shots=100)
             >>> for sample in sampleset.samples():
@@ -359,7 +367,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -374,7 +382,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(device_arn_1, s3_destination_folder)
+            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -387,7 +395,6 @@ class BraketSampler(Sampler, Structured):
         solver_kwargs = self._process_solver_kwargs(**kwargs)
 
         sorted_edges = frozenset((u, v) if u < v else (v, u) for u, v in Q)
-        print(self._access_optimized_edgelist())
         for u, v in sorted_edges:
             if u not in self._access_optimized_nodelist():
                 raise BinaryQuadraticModelStructureError(

--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -187,7 +187,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> h = {0: -1, 1: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -200,7 +200,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> h = {30: -1, 31: 1}
             >>> sampleset = sampler.sample_ising(h, {}, resultFormat="HISTOGRAM")
             >>> for sample in sampleset.samples():
@@ -251,7 +251,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {0: 1, 1: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -265,7 +265,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {30: 1, 31: 1}
             >>> task = sampler.sample_ising_quantum_task(Q, {}, resultFormat="HISTOGRAM")
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -316,7 +316,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> sampleset = sampler.sample_qubo(Q, postprocessingType="SAMPLING", shots=100)
             >>> for sample in sampleset.samples():
@@ -329,7 +329,7 @@ class BraketSampler(Sampler, Structured):
             30 and 31 on a sampler on the D-Wave Advantage4 device.
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> sampleset = sampler.sample_qubo(Q, shots=100)
             >>> for sample in sampleset.samples():
@@ -367,7 +367,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/DW_2000Q_6"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {(0, 0): -1, (4, 4): -1, (0, 4): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)
@@ -382,7 +382,7 @@ class BraketSampler(Sampler, Structured):
 
             >>> from braket.ocean_plugin import BraketSampler
             >>> device_arn_1 = "arn:aws:braket:::device/qpu/d-wave/Advantage_system4"
-            >>> sampler = BraketSampler(s3_destination_folder,device_arn_1)
+            >>> sampler = BraketSampler(device_arn_1)
             >>> Q = {(30, 30): -1, (31, 31): -1, (30, 31): 2}
             >>> task = sampler.sample_qubo_quantum_task(Q, resultFormat="HISTOGRAM", shots=100)
             >>> sampleset = BraketSampler.get_task_sample_set(task)

--- a/test/integ_tests/test_braket_dwave_sampler_running.py
+++ b/test/integ_tests/test_braket_dwave_sampler_running.py
@@ -21,7 +21,7 @@ def test_factoring_embedded_composite(
     dwave_arn, aws_session, s3_destination_folder, factoring_bqm, integer_to_factor
 ):
     sampler = BraketDWaveSampler(
-        device_arn=dwave_arn, s3_destination_folder=s3_destination_folder, aws_session=aws_session
+        s3_destination_folder=s3_destination_folder, device_arn=dwave_arn, aws_session=aws_session
     )
     embedding_sampler = EmbeddingComposite(sampler)
     response = embedding_sampler.sample(

--- a/test/integ_tests/test_braket_dwave_sampler_running.py
+++ b/test/integ_tests/test_braket_dwave_sampler_running.py
@@ -21,7 +21,7 @@ def test_factoring_embedded_composite(
     dwave_arn, aws_session, s3_destination_folder, factoring_bqm, integer_to_factor
 ):
     sampler = BraketDWaveSampler(
-        s3_destination_folder, device_arn=dwave_arn, aws_session=aws_session
+        device_arn=dwave_arn, s3_destination_folder=s3_destination_folder, aws_session=aws_session
     )
     embedding_sampler = EmbeddingComposite(sampler)
     response = embedding_sampler.sample(

--- a/test/integ_tests/test_braket_sampler_running.py
+++ b/test/integ_tests/test_braket_sampler_running.py
@@ -22,7 +22,7 @@ def test_factoring_minorminer(
     dwave_arn, aws_session, s3_destination_folder, factoring_bqm, integer_to_factor
 ):
     sampler = BraketSampler(
-        device_arn=dwave_arn, s3_destination_folder=s3_destination_folder, aws_session=aws_session
+        s3_destination_folder=s3_destination_folder, device_arn=dwave_arn, aws_session=aws_session
     )
     _, target_edgelist, target_adjacency = sampler.structure
     embedding = minorminer.find_embedding(factoring_bqm.quadratic, target_edgelist)

--- a/test/integ_tests/test_braket_sampler_running.py
+++ b/test/integ_tests/test_braket_sampler_running.py
@@ -21,7 +21,9 @@ from braket.ocean_plugin import BraketSampler
 def test_factoring_minorminer(
     dwave_arn, aws_session, s3_destination_folder, factoring_bqm, integer_to_factor
 ):
-    sampler = BraketSampler(s3_destination_folder, device_arn=dwave_arn, aws_session=aws_session)
+    sampler = BraketSampler(
+        device_arn=dwave_arn, s3_destination_folder=s3_destination_folder, aws_session=aws_session
+    )
     _, target_edgelist, target_adjacency = sampler.structure
     embedding = minorminer.find_embedding(factoring_bqm.quadratic, target_edgelist)
     bqm_embedded = embed_bqm(factoring_bqm, embedding, target_adjacency, 3.0)

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -50,13 +50,14 @@ def device_parameters_2():
     return {BraketSolverMetadata.DWAVE["device_parameters_key_name"]: {}}
 
 
+# Removed s3_destination_folder fixture parameter.
 @pytest.fixture
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
 def braket_dwave_sampler(
     mock_qpu, braket_sampler_properties, s3_destination_folder, logger, dwave_arn
 ):
     mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketDWaveSampler(s3_destination_folder, dwave_arn, Mock(), logger)
+    sampler = BraketDWaveSampler(dwave_arn, s3_destination_folder, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     return sampler
 
@@ -75,7 +76,7 @@ def test_default_device_arn(
     mock_device.arn = dwave_arn
     dwave_sampler_mock_qpu.get_devices.return_value = [mock_device]
     sampler_mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
+    sampler = BraketDWaveSampler(None, s3_destination_folder, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     assert sampler._device_arn == dwave_arn
 
@@ -86,7 +87,7 @@ def test_default_device_arn_error(dwave_sampler_mock_qpu, s3_destination_folder,
     mock_device = Mock()
     mock_device.arn = dwave_arn
     dwave_sampler_mock_qpu.get_devices.return_value = []
-    BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
+    BraketDWaveSampler(None, s3_destination_folder, Mock(), logger)
 
 
 def test_parameters(braket_dwave_sampler):

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -57,15 +57,13 @@ def braket_dwave_sampler(
     mock_qpu, braket_sampler_properties, s3_destination_folder, logger, dwave_arn
 ):
     mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketDWaveSampler(dwave_arn, s3_destination_folder, Mock(), logger)
+    sampler = BraketDWaveSampler(s3_destination_folder, dwave_arn, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     return sampler
 
 
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
-@patch("braket.ocean_plugin.braket_dwave_sampler.AwsDevice")
 def test_default_device_arn(
-    dwave_sampler_mock_qpu,
     sampler_mock_qpu,
     braket_sampler_properties,
     s3_destination_folder,
@@ -74,20 +72,20 @@ def test_default_device_arn(
 ):
     mock_device = Mock()
     mock_device.arn = dwave_arn
-    dwave_sampler_mock_qpu.get_devices.return_value = [mock_device]
+    sampler_mock_qpu.get_devices.return_value = [mock_device]
     sampler_mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketDWaveSampler(None, s3_destination_folder, Mock(), logger)
+    sampler = BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
     assert isinstance(sampler, BraketSampler)
     assert sampler._device_arn == dwave_arn
 
 
 @pytest.mark.xfail(raises=RuntimeError)
-@patch("braket.ocean_plugin.braket_dwave_sampler.AwsDevice")
-def test_default_device_arn_error(dwave_sampler_mock_qpu, s3_destination_folder, logger, dwave_arn):
+@patch("braket.ocean_plugin.braket_sampler.AwsDevice")
+def test_default_device_arn_error(sampler_mock_qpu, s3_destination_folder, logger, dwave_arn):
     mock_device = Mock()
     mock_device.arn = dwave_arn
-    dwave_sampler_mock_qpu.get_devices.return_value = []
-    BraketDWaveSampler(None, s3_destination_folder, Mock(), logger)
+    sampler_mock_qpu.get_devices.return_value = []
+    BraketDWaveSampler(s3_destination_folder, None, Mock(), logger)
 
 
 def test_parameters(braket_dwave_sampler):

--- a/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
@@ -50,7 +50,7 @@ def device_parameters(braket_dwave_parameters):
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
 def braket_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder, logger, dwave_arn):
     mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketSampler(dwave_arn, s3_destination_folder, Mock(), logger)
+    sampler = BraketSampler(s3_destination_folder, dwave_arn, Mock(), logger)
     return sampler
 
 
@@ -60,7 +60,7 @@ def advantage_braket_sampler(
     mock_qpu, advantage_braket_sampler_properties, s3_destination_folder, logger, dwave_arn
 ):
     mock_qpu.return_value.properties = advantage_braket_sampler_properties
-    sampler = BraketSampler(dwave_arn, s3_destination_folder, Mock(), logger)
+    sampler = BraketSampler(s3_destination_folder, dwave_arn, Mock(), logger)
     return sampler
 
 
@@ -96,6 +96,23 @@ def test_edgelist(braket_sampler):
 
 def test_nodelist(braket_sampler):
     assert braket_sampler.nodelist == (0, 1, 2)
+
+
+@patch("braket.ocean_plugin.braket_sampler.AwsDevice")
+def test_default_device_arn(
+    sampler_mock_qpu,
+    braket_sampler_properties,
+    s3_destination_folder,
+    logger,
+    dwave_arn,
+):
+    mock_device = Mock()
+    mock_device.arn = dwave_arn
+    sampler_mock_qpu.get_devices.return_value = [mock_device]
+    sampler_mock_qpu.return_value.properties = braket_sampler_properties
+    sampler = BraketSampler(s3_destination_folder, None, Mock(), logger)
+    assert isinstance(sampler, BraketSampler)
+    assert sampler._device_arn == dwave_arn
 
 
 @pytest.mark.xfail(raises=BinaryQuadraticModelStructureError)

--- a/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_sampler.py
@@ -50,7 +50,7 @@ def device_parameters(braket_dwave_parameters):
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
 def braket_sampler(mock_qpu, braket_sampler_properties, s3_destination_folder, logger, dwave_arn):
     mock_qpu.return_value.properties = braket_sampler_properties
-    sampler = BraketSampler(s3_destination_folder, dwave_arn, Mock(), logger)
+    sampler = BraketSampler(dwave_arn, s3_destination_folder, Mock(), logger)
     return sampler
 
 
@@ -60,7 +60,7 @@ def advantage_braket_sampler(
     mock_qpu, advantage_braket_sampler_properties, s3_destination_folder, logger, dwave_arn
 ):
     mock_qpu.return_value.properties = advantage_braket_sampler_properties
-    sampler = BraketSampler(s3_destination_folder, dwave_arn, Mock(), logger)
+    sampler = BraketSampler(dwave_arn, s3_destination_folder, Mock(), logger)
     return sampler
 
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- s3_destination folder should not be a a mandatory parameter for DwaveSampler notebooks, default bucket is created if s3 details are not provided by the customer.
- device_arn no longer mandatory for BraketSampler, defaults to first available online d-wave device, like BraketDwaveSampler

*Testing done:*
tox unit/integ, ran all examples without s3 bucket and verified braket sampler works without device arn

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
