### PR TITLE
fix: initial state error for reverse annealing

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -32,6 +32,7 @@ setup(
         "boltons>=20.0.0",
         "colorama>=0.4.3",
         "dimod>=0.8.13",
+        "dwave-cloud-client>=0.9.4",
         "jsonref",
         "wheel>=0.36.2",
     ],

--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -153,7 +153,8 @@ class BraketDWaveSampler(BraketSampler):
             ...
             {30: 1, 31: -1}
         """
-        return super().sample_ising(h, J, **kwargs)
+        reformatted_params = StructuredSolver.reformat_parameters("ising", kwargs, self.properties)
+        return super().sample_ising(h, J, **reformatted_params)
 
     def sample_ising_quantum_task(
         self, h: Union[Dict[int, float], List[float]], J: Dict[Tuple[int, int], float], **kwargs
@@ -209,8 +210,8 @@ class BraketDWaveSampler(BraketSampler):
             ...
             {30: 1, 31: -1}
         """
-        self.vartype = "ising"
-        return super().sample_ising_quantum_task(h, J, **kwargs)
+        reformatted_params = StructuredSolver.reformat_parameters("ising", kwargs, self.properties)
+        return super().sample_ising_quantum_task(h, J, **reformatted_params)
 
     def sample_qubo(self, Q: Dict[Tuple[int, int], float], **kwargs) -> SampleSet:
         """
@@ -253,7 +254,8 @@ class BraketDWaveSampler(BraketSampler):
             {30: 0, 31: 1}
             {30: 1, 31: 0}
         """
-        return super().sample_qubo(Q, **kwargs)
+        reformatted_params = StructuredSolver.reformat_parameters("qubo", kwargs, self.properties)
+        return super().sample_qubo(Q, **reformatted_params)
 
     def sample_qubo_quantum_task(self, Q: Dict[Tuple[int, int], float], **kwargs) -> QuantumTask:
         """
@@ -300,8 +302,8 @@ class BraketDWaveSampler(BraketSampler):
             {30: 0, 31: 1}
             {30: 1, 31: 0}
         """
-        self.vartype = "qubo"
-        return super().sample_qubo_quantum_task(Q, **kwargs)
+        reformatted_params = StructuredSolver.reformat_parameters("qubo", kwargs, self.properties)
+        return super().sample_qubo_quantum_task(Q, **reformatted_params)
 
     def _process_solver_kwargs(self, **kwargs) -> Dict[str, Any]:
         """
@@ -314,14 +316,9 @@ class BraketDWaveSampler(BraketSampler):
         """
         self._check_kwargs_solver(**kwargs)
 
-        reformatted_params = StructuredSolver.reformat_parameters(
-            self.vartype, kwargs, self.properties
-        )
         # Translate kwargs from D-Wave format to Braket format
         parameter_dict = BraketSolverMetadata.get_metadata_by_arn(self._device_arn)["parameters"]
-        translated_kwargs = {
-            parameter_dict[key]: reformatted_params[key] for key in reformatted_params
-        }
+        translated_kwargs = {parameter_dict[key]: kwargs[key] for key in kwargs}
         if "resultFormat" in translated_kwargs:
             translated_kwargs["resultFormat"] = translated_kwargs["resultFormat"].upper()
         if "postprocessingType" in translated_kwargs:

--- a/test/unit_tests/braket/ocean_plugin/conftest.py
+++ b/test/unit_tests/braket/ocean_plugin/conftest.py
@@ -149,6 +149,16 @@ def active_variables():
     return [4, 5, 6]
 
 
+@pytest.fixture
+def reverse_schedule():
+    return [[0, 1.0], [1, 0.5], [999, 0.5], [1000, 1.0]]
+
+
+@pytest.fixture
+def initial_state_ising_dict():
+    return {0: 1, 1: 1, 2: 1}
+
+
 @pytest.fixture()
 def additional_metadata(active_variables):
     return {
@@ -317,6 +327,9 @@ def sample_ising_common_testing(
     assert actual.vartype == SPIN
     assert actual.record.sample.shape == (3, 3)
     assert actual.info == info
+
+
+# add test for reverse annealing
 
 
 def sample_qubo_quantum_task_common_testing(

--- a/test/unit_tests/braket/ocean_plugin/conftest.py
+++ b/test/unit_tests/braket/ocean_plugin/conftest.py
@@ -329,9 +329,6 @@ def sample_ising_common_testing(
     assert actual.info == info
 
 
-# add test for reverse annealing
-
-
 def sample_qubo_quantum_task_common_testing(
     sampler,
     s3_qubo_result,

--- a/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
+++ b/test/unit_tests/braket/ocean_plugin/test_braket_dwave_sampler.py
@@ -50,6 +50,25 @@ def device_parameters_2():
     return {BraketSolverMetadata.DWAVE["device_parameters_key_name"]: {}}
 
 
+@pytest.fixture
+def sample_kwargs_3(shots, reverse_schedule, initial_state_ising_dict):
+    return {
+        "num_reads": shots,
+        "anneal_schedule": reverse_schedule,
+        "initial_state": initial_state_ising_dict,
+    }
+
+
+@pytest.fixture
+def device_parameters_3():
+    return {
+        BraketSolverMetadata.DWAVE["device_parameters_key_name"]: {
+            "annealingSchedule": [[0, 1.0], [1, 0.5], [999, 0.5], [1000, 1.0]],
+            "initialState": [1, 1, 1],
+        }
+    }
+
+
 # Removed s3_destination_folder fixture parameter.
 @pytest.fixture
 @patch("braket.ocean_plugin.braket_sampler.AwsDevice")
@@ -160,6 +179,31 @@ def test_sample_ising_quantum_task_success(
         s3_destination_folder,
         device_parameters_1,
         sample_kwargs_1,
+        shots,
+        logger,
+    )
+
+
+@pytest.mark.parametrize("linear, quadratic", [({0: -1, 1: 1, 2: -1}, {}), ([-1, 1, -1], {})])
+def test_sample_ising_initial_state_dict(
+    linear,
+    quadratic,
+    braket_dwave_sampler,
+    s3_ising_result,
+    s3_destination_folder,
+    device_parameters_3,
+    sample_kwargs_3,
+    shots,
+    logger,
+):
+    sample_ising_quantum_task_common_testing(
+        linear,
+        quadratic,
+        braket_dwave_sampler,
+        s3_ising_result,
+        s3_destination_folder,
+        device_parameters_3,
+        sample_kwargs_3,
         shots,
         logger,
     )


### PR DESCRIPTION
*Issue #, if available:* #67

*Description of changes:* 

- Added dependency on `dwave-cloud-client>=0.9.4`.
- Added call to `dwave.cloud.solver.StructuredSolver.reformat_parameters()` before translating from D-Wave format to Braket format.
- Added `self.vartype` in `sample_ising_quantum_task` and `sample_qubo_quantum_task` functions in `BraketDWaveSampler` so that the problem type is available in `_process_solver_kwargs()`. I'm not sure if this is the best way, but it's simple and works.

*Testing done:* I didn't add any new tests, but I ran `tox` successfully.

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
