### PR TITLE
fix: docstrings for samplers

### DIFF
--- a/src/braket/ocean_plugin/braket_dwave_sampler.py
+++ b/src/braket/ocean_plugin/braket_dwave_sampler.py
@@ -16,7 +16,7 @@ from __future__ import annotations
 import copy
 from functools import lru_cache
 from logging import Logger, getLogger
-from typing import Any, Dict, List, Tuple, Union
+from typing import Any, Dict, List, Optional, Tuple, Union
 
 import jsonref
 from boltons.dictutils import FrozenDict
@@ -34,22 +34,22 @@ class BraketDWaveSampler(BraketSampler):
     A class for using DWave-formatted parameters and properties with Amazon Braket as a sampler.
 
     Args:
-        s3_destination_folder (AwsSession.S3DestinationFolder): NamedTuple with bucket (index 0)
-            and key (index 1) that is the results destination folder in S3.
+        s3_destination_folder (AwsSession.S3DestinationFolder, optional): NamedTuple with bucket
+        (index 0) and key (index 1) to save the task's results in S3.
+        Default is `<default_bucket>/tasks`.
         device_arn (str): AWS quantum device arn. Default is the latest D-Wave QPU device ARN.
-        aws_session (AwsSession): AwsSession to call AWS with.
+        aws_session (AwsSession): AwsSession to call AWS with. Default is `None`.
         logger (Logger): Python Logger object with which to write logs, such as `QuantumTask`
             statuses while polling for task to complete. Default is `getLogger(__name__)`
 
     Examples:
         >>> from braket.ocean_plugin import BraketDWaveSampler
-        >>> s3_destination_folder = ('test_bucket', 'test_folder')
-        >>> sampler = BraketDWaveSampler(s3_destination_folder)
+        >>> sampler = BraketDWaveSampler()
     """
 
     def __init__(
         self,
-        s3_destination_folder: AwsSession.S3DestinationFolder = None,
+        s3_destination_folder: Optional[AwsSession.S3DestinationFolder] = None,
         device_arn: str = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),

--- a/src/braket/ocean_plugin/braket_sampler.py
+++ b/src/braket/ocean_plugin/braket_sampler.py
@@ -18,7 +18,7 @@ import copy
 from collections import defaultdict
 from functools import lru_cache
 from logging import Logger, getLogger
-from typing import Any, Dict, FrozenSet, List, Set, Tuple, Union
+from typing import Any, Dict, FrozenSet, List, Optional, Set, Tuple, Union
 
 import jsonref
 from boltons.dictutils import FrozenDict
@@ -36,22 +36,22 @@ class BraketSampler(Sampler, Structured):
     A class for using Amazon Braket as a sampler
 
     Args:
-        s3_destination_folder (AwsSession.S3DestinationFolder): NamedTuple with bucket (index 0)
-            and key (index 1) that is the results destination folder in S3.
-        device_arn (str): AWS quantum device arn.
-        aws_session (AwsSession): AwsSession to call AWS with.
+        s3_destination_folder (AwsSession.S3DestinationFolder, optional): NamedTuple with bucket
+        (index 0) and key (index 1) to save the task's results in S3.
+        Default is `<default_bucket>/tasks`
+        device_arn (str): AWS quantum device arn. Default is the latest D-Wave QPU device ARN.
+        aws_session (AwsSession): AwsSession to call AWS with. Default is `None`.
         logger (Logger): Python Logger object with which to write logs, such as `QuantumTask`
             statuses while polling for task to complete. Default is `getLogger(__name__)`
 
     Examples:
         >>> from braket.ocean_plugin import BraketSampler
-        >>> s3_destination_folder = ('test_bucket', 'test_folder')
-        >>> sampler = BraketSampler(s3_destination_folder, "device_arn_1")
+        >>> sampler = BraketSampler()
     """
 
     def __init__(
         self,
-        s3_destination_folder: AwsSession.S3DestinationFolder = None,
+        s3_destination_folder: Optional[AwsSession.S3DestinationFolder] = None,
         device_arn: str = None,
         aws_session: AwsSession = None,
         logger: Logger = getLogger(__name__),


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
- Fixed docstring parameters with default values and remove s3 config description. 

*Testing done:*
tox, lint, integ-tests

## Merge Checklist

_Put an `x` in the boxes that apply. You can also fill these out after creating the PR. If you're unsure about any of them, don't hesitate to ask. We're here to help! This is simply a reminder of what we are going to look for before merging your pull request._

#### General

- [x] I have read the [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md) doc
- [x] I used the commit message format described in [CONTRIBUTING](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#commit-your-change)
- [x] I have updated any necessary documentation, including [READMEs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/README.md) and [API docs](https://github.com/aws/amazon-braket-ocean-plugin-python/blob/main/CONTRIBUTING.md#documentation-guidelines) (if appropriate)

#### Tests

- [x] I have added tests that prove my fix is effective or that my feature works (if appropriate)
- [x] I have checked that my tests are not configured for a specific region or account (if appropriate)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
